### PR TITLE
New options to set some of the oidc endpoints when they are not standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Or supply the `PROVIDER_URL` option setting in an environment variable called `K
 
 
 ### OIDC endpoints
-In case some of the endpoints returned by the OIDC discovery url `.well-known/openid-configuration` are not standard, you can set them using these options either in the `$KOLIBRI_HOME/options.ini` file or suplying them in an environment variable.
+
+In case some of the endpoints returned by the OIDC discovery url `.well-known/openid-configuration` are not standard, you can set them using these options either in the `$KOLIBRI_HOME/options.ini` file or by supplying them in an environment variable.
+
+In the `options.ini` file:
+
 ```ini
 [OIDCClient]
 JWKS_URI=

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ AUTHORIZATION_ENDPOINT=
 TOKEN_ENDPOINT=
 USERINFO_ENDPOINT=
 ```
-The environment variables for these options are, in order:
+
+Or, as environment variables:
+
 ```
 KOLIBRI_OIDC_JWKS_URI
 KOLIBRI_OIDC_AUTHORIZATION_ENDPOINT

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ PROVIDER_URL=url of the OIDC provider
 Or supply the `PROVIDER_URL` option setting in an environment variable called `KOLIBRI_OIDC_CLIENT_URL`.
 
 
+### OIDC endpoints
+In case some of the endpoints returned by the OIDC discovery url `.well-known/openid-configuration` are not standard, you can set them using these options either in the `$KOLIBRI_HOME/options.ini` file or suplying them in an environment variable.
+```ini
+[OIDCClient]
+JWKS_URI=
+AUTHORIZATION_ENDPOINT=
+TOKEN_ENDPOINT=
+USERINFO_ENDPOINT=
+```
+The environment variables for these options are, in order:
+```
+KOLIBRI_OIDC_JWKS_URI
+KOLIBRI_OIDC_AUTHORIZATION_ENDPOINT
+KOLIBRI_OIDC_TOKEN_ENDPOINT
+KOLIBRI_OIDC_USERINFO_ENDPOINT
+```
+
+
 ### OIDC provider credentials
 
 In order to the client requests to be authorized by the OIDC provider, a client ID and a client password must be used. These values must have been provided by the OIDC server provider.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package provides Kolibri users with the ability to authenticate against an 
 
 ## How can I install this plugin?
 
-1. Inside your Kolibri virtual environment: `pip install kolibri_oidc_client_plugin`
+1. Inside your Kolibri virtual environment: `pip install kolibri-oidc-client-plugin`
 
 2. Activate the plugin: `kolibri plugin enable kolibri_oidc_client_plugin`
 

--- a/kolibri_oidc_client_plugin/options.py
+++ b/kolibri_oidc_client_plugin/options.py
@@ -24,6 +24,6 @@ option_spec = {
             "type": "string",
             "default": "",
             "envvars": ("KOLIBRI_OIDC_JWKS_URI",),
-        }
+        },
     }
 }

--- a/kolibri_oidc_client_plugin/options.py
+++ b/kolibri_oidc_client_plugin/options.py
@@ -4,6 +4,26 @@ option_spec = {
             "type": "string",
             "default": "http://127.0.0.1:5002/oauth",
             "envvars": ("KOLIBRI_OIDC_CLIENT_URL",),
+        },
+        "AUTHORIZATION_ENDPOINT": {
+            "type": "string",
+            "default": "",
+            "envvars": ("KOLIBRI_OIDC_AUTHORIZATION_ENDPOINT",),
+        },
+        "TOKEN_ENDPOINT": {
+            "type": "string",
+            "default": "",
+            "envvars": ("KOLIBRI_OIDC_TOKEN_ENDPOINT",),
+        },
+        "USERINFO_ENDPOINT": {
+            "type": "string",
+            "default": "",
+            "envvars": ("KOLIBRI_OIDC_USERINFO_ENDPOINT",),
+        },
+        "JWKS_URI": {
+            "type": "string",
+            "default": "",
+            "envvars": ("KOLIBRI_OIDC_JWKS_URI",),
         }
     }
 }

--- a/kolibri_oidc_client_plugin/settings.py
+++ b/kolibri_oidc_client_plugin/settings.py
@@ -12,10 +12,18 @@ OIDC_RP_CLIENT_ID = os.environ.get("CLIENT_ID", "kolibri.app")
 OIDC_RP_CLIENT_SECRET = os.environ.get("CLIENT_SECRET", "kolibri.app")
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_AUTHENTICATION_CALLBACK_URL = "oidc_client:oidc_authentication_callback"
-OIDC_OP_AUTHORIZATION_ENDPOINT = "{}/authorize".format(OIDC_URL)
-OIDC_OP_JWKS_ENDPOINT = "{}/jwks".format(OIDC_URL)
-OIDC_OP_TOKEN_ENDPOINT = "{}/token".format(OIDC_URL)
-OIDC_OP_USER_ENDPOINT = "{}/userinfo".format(OIDC_URL)
+OIDC_OP_AUTHORIZATION_ENDPOINT = OPTIONS["OIDCClient"][
+    "AUTHORIZATION_ENDPOINT"
+] or "{}/authorize".format(OIDC_URL)
+OIDC_OP_JWKS_ENDPOINT = OPTIONS["OIDCClient"]["JWKS_URI"] or "{}/jwks".format(
+    OIDC_URL
+)
+OIDC_OP_TOKEN_ENDPOINT = OPTIONS["OIDCClient"]["TOKEN_ENDPOINT"] or "{}/token".format(
+    OIDC_URL
+)
+OIDC_OP_USER_ENDPOINT = OPTIONS["OIDCClient"]["USERINFO_ENDPOINT"] or "{}/userinfo".format(
+    OIDC_URL
+)
 OIDC_VERIFY_SSL = False
 OIDC_TOKEN_USE_BASIC_AUTH = True
 OIDC_RP_SCOPES = "openid profile"


### PR DESCRIPTION
In some cases, OIDC providers are not using the standard routes `authorize`, `jwks`, `userinfo` or `token` for these endpoints. This PR allows the plugin user to set the absolute url for any of these endpoints in case it's needed via `options.ini` or environment variables.
options.ini example overriding the standard value for `jwks` and `authorize`:

```ini
[OIDCClient]
PROVIDER_URL=http://localhost:8080/auth/realms/master/protocol/openid-connect
JWKS_URI=http://localhost:8080/auth/realms/master/protocol/openid-connect/certs
AUTHORIZATION_ENDPOINT=http://localhost:8080/auth/realms/master/protocol/openid-connect/auth
```
