### PR TITLE
Add more fields to the user creation and add roles if they are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ This package provides Kolibri users with the ability to authenticate against an 
 3. Restart Kolibri
 
 
+## Used claims
+This plugin will create a new user in the Kolibri database after it authenticates using the OIDC provider.
+From the [standard OIDC claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) the plugin will fetch these ones to add the information to the database:
+
+- `nickname` (or `username`)
+- `given_name`
+- `family_name`
+- `email`
+- `birthdate`
+- `gender`
+
+Apart from these standard claims, the plugin will accept a list of `roles` in the user_info token provided in a string with the format "roles":[role1, role2....]
+As an user_info token payload example:
+```json
+{"email":"jhon@doe.com", "username":"jdoe", "roles":["coach","admin"], "family_name":"Doe"}
+```
+
+
 ## Plugin configuration
 
 This plugin is based on the [Mozilla Django OIDC library](https://mozilla-django-oidc.readthedocs.io/en/stable/). The plugin has been set to work with a standard OpenID Connect provider, so most of the library options have already been set and are not optional.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,15 @@ From the [standard OIDC claims](https://openid.net/specs/openid-connect-core-1_0
 - `birthdate`
 - `gender`
 
-Apart from these standard claims, the plugin will accept a list of `roles` in the user_info token provided in a string with the format "roles":[role1, role2....]
+In case `birthdate`is provided, the accepted format is  [ISO8601‑2004] YYYY-MM-DD. However Kolibri only stores the year of birth.
+
+Apart from these standard claims, the plugin will accept a  `roles` in the user_info token provided as a list. Allowed roles are only `admin` or `coach`.
+If the role is not provided the user is created as a learner.
+
 As an user_info token payload example:
 ```json
-{"email":"jhon@doe.com", "username":"jdoe", "roles":["coach","admin"], "family_name":"Doe"}
+{"email":"jhon@doe.com", "username":"jdoe", "roles":"['coach']", "family_name":"Doe"}
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ This package provides Kolibri users with the ability to authenticate against an 
 
 
 ## Used claims
+
 This plugin will create a new user in the Kolibri database after it authenticates using the OIDC provider.
-From the [standard OIDC claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) the plugin will fetch these ones to add the information to the database:
+From the [standard OIDC claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) the plugin will fetch the following fields and add the information to the Kolibri user database:
 
 - `nickname` (or `username`)
 - `given_name`

--- a/kolibri_oidc_client_plugin/auth.py
+++ b/kolibri_oidc_client_plugin/auth.py
@@ -76,8 +76,11 @@ class OIDCKolibriAuthenticationBackend(OIDCAuthenticationBackend):
         email = claims.get("email", username)
         # Kolibri doesn't allow an empty password. This isn't going to be used:
         password = uuid4().hex
-        birthdate = claims.get("birthdate", "NOT_SPECIFIED")
-        gender = claims.get("gender", "NOT_SPECIFIED")
+        # birthdate format is [ISO8601‑2004] YYYY-MM-DD
+        birthdate = (
+            claims.get("birthdate")[:4] if "birthdate" in claims else "NOT_SPECIFIED"
+        )
+        gender = claims.get("gender", "NOT_SPECIFIED").upper()
         user = self.UserModel.objects.create_user(
             username,
             email=email,

--- a/kolibri_oidc_client_plugin/auth.py
+++ b/kolibri_oidc_client_plugin/auth.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 class OIDCKolibriAuthenticationBackend(OIDCAuthenticationBackend):
     def get_username(self, claim):
-        username = claim.get("nickname")  # according to https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+        username = claim.get(
+            "nickname"
+        )  # according to https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
         if not username:  # according to OLIP implementation
             username = claim.get("username")
         return username
@@ -67,7 +69,9 @@ class OIDCKolibriAuthenticationBackend(OIDCAuthenticationBackend):
         username = self.get_username(claims)
         full_name = claims.get("name", "")
         if not full_name:
-            full_name = '{} {}'.format(claims.get('given_name', ""), claims.get('family_name', ""))
+            full_name = "{} {}".format(
+                claims.get("given_name", ""), claims.get("family_name", "")
+            )
         # not needed in Kolibri, email is not mandatory:
         email = claims.get("email", username)
         # Kolibri doesn't allow an empty password. This isn't going to be used:
@@ -75,8 +79,12 @@ class OIDCKolibriAuthenticationBackend(OIDCAuthenticationBackend):
         birthdate = claims.get("birthdate", "NOT_SPECIFIED")
         gender = claims.get("gender", "NOT_SPECIFIED")
         user = self.UserModel.objects.create_user(
-            username, email=email, full_name=full_name, password=password,
-            birth_year=birthdate, gender=gender
+            username,
+            email=email,
+            full_name=full_name,
+            password=password,
+            birth_year=birthdate,
+            gender=gender,
         )
 
         # check if the user has assigned roles and assign them in such case

--- a/kolibri_oidc_client_plugin/auth.py
+++ b/kolibri_oidc_client_plugin/auth.py
@@ -1,6 +1,5 @@
 import logging
 from uuid import uuid4
-
 from kolibri.core.auth.errors import InvalidRoleKind
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from mozilla_django_oidc.auth import SuspiciousOperation
@@ -93,9 +92,10 @@ class OIDCKolibriAuthenticationBackend(OIDCAuthenticationBackend):
         # check if the user has assigned roles and assign them in such case
         roles = claims.get("roles", [])
         for role in roles:
-            try:
-                user.facility.add_role(user, role.lower())
-            except InvalidRoleKind:
-                pass  # The role does not exist in Kolibri
+            if role.lower() in ("admin", "coach"):
+                try:
+                    user.facility.add_role(user, role.lower())
+                except InvalidRoleKind:
+                    pass  # The role does not exist in Kolibri
 
         return user


### PR DESCRIPTION
When OIDC client plugin is used in Kolibri, the very first time an user logins using an OIDC provider will trigger the creation of this user in the Kolibri database. With this plugin:

- More fields: email, birthdate and gender will be added to the user info in the database
- If a roles list is provided, the user will be added to these roles.


Closes: #3