### PR TITLE
Added logout from server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,19 @@ For it to work correctly, the `ENDSESSION_ENDPOINT` must contain the OIDC provid
 #### Configuration example
 This is the options.ini used to login and logout from a [KeyCloak](https://www.keycloak.org/) server:
 
-`[Deployment]`
-`HTTP_PORT = 9000`
+```ini
+[Deployment]
+HTTP_PORT = 9000
 
-`[OIDCClient]`
-`PROVIDER_URL = http://localhost:8080/auth/realms/master`
-`AUTHORIZATION_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/auth`
-`TOKEN_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/token`
-`USERINFO_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/userinfo`
-`JWKS_URI = http://localhost:8080/auth/realms/master/protocol/openid-connect/certs`
-`ENDSESSION_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/logout`
-`CLIENT_URL = http://localhost:9000`
+[OIDCClient]
+PROVIDER_URL = http://localhost:8080/auth/realms/master
+AUTHORIZATION_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/auth
+TOKEN_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/token
+USERINFO_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/userinfo
+JWKS_URI = http://localhost:8080/auth/realms/master/protocol/openid-connect/certs
+ENDSESSION_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/logout
+CLIENT_URL = http://localhost:9000
+```
 
 ### OIDC provider credentials
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ KOLIBRI_CLIENT_URL
 
 ### Ending session in the OIDC provider from kolibri
 If kolibri >= 0.14 is used, kolibri will be able to end the user session in the OIDC provider when the use logs out.
-For it to work correctly, the `ENDSESSION_ENDPOINT` must contain the OIDC provider url to end the session and another option: `CLIENT_URL` must be set containing the exact base url of the server running Kolibri, for example: http://localhost:8000 . This feature is available only if kolibri version >= 0.14
+For it to work correctly, the `ENDSESSION_ENDPOINT` must contain the OIDC provider url to end the session and another option: `CLIENT_URL` must be set containing the exact base url of the server running Kolibri, for example: http://localhost:9000 . This feature is available only if kolibri version >= 0.14
 
 #### Configuration example
 This is the options.ini used to login and logout from a [KeyCloak](https://www.keycloak.org/) server:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ JWKS_URI=
 AUTHORIZATION_ENDPOINT=
 TOKEN_ENDPOINT=
 USERINFO_ENDPOINT=
+ENDSESSION_ENDPOINT=
+CLIENT_URL=
+
 ```
 
 Or, as environment variables:
@@ -61,8 +64,13 @@ KOLIBRI_OIDC_JWKS_URI
 KOLIBRI_OIDC_AUTHORIZATION_ENDPOINT
 KOLIBRI_OIDC_TOKEN_ENDPOINT
 KOLIBRI_OIDC_USERINFO_ENDPOINT
+KOLIBRI_OIDC_ENDSESSION_ENDPOINT
+KOLIBRI_CLIENT_URL
 ```
 
+### Ending session in the OIDC provider from kolibri
+If kolibri >= 0.14 is used, kolibri will be able to end the user session in the OIDC provider when the use logs out.
+For it to work correctly, the `ENDSESSION_ENDPOINT` must contain the OIDC provider url to end the session and another option: `CLIENT_URL` must be set containing the exact base url of the server running Kolibri, for example: http://localhost:8000 . This feature is available only if kolibri version >= 0.14
 
 ### OIDC provider credentials
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ KOLIBRI_CLIENT_URL
 If kolibri >= 0.14 is used, kolibri will be able to end the user session in the OIDC provider when the use logs out.
 For it to work correctly, the `ENDSESSION_ENDPOINT` must contain the OIDC provider url to end the session and another option: `CLIENT_URL` must be set containing the exact base url of the server running Kolibri, for example: http://localhost:8000 . This feature is available only if kolibri version >= 0.14
 
+#### Configuration example
+This is the options.ini used to login and logout from a [KeyCloak](https://www.keycloak.org/) server:
+
+`[Deployment]`
+`HTTP_PORT = 9000`
+
+`[OIDCClient]`
+`PROVIDER_URL = http://localhost:8080/auth/realms/master`
+`AUTHORIZATION_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/auth`
+`TOKEN_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/token`
+`USERINFO_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/userinfo`
+`JWKS_URI = http://localhost:8080/auth/realms/master/protocol/openid-connect/certs`
+`ENDSESSION_ENDPOINT = http://localhost:8080/auth/realms/master/protocol/openid-connect/logout`
+`CLIENT_URL = http://localhost:9000`
+
 ### OIDC provider credentials
 
 In order to the client requests to be authorized by the OIDC provider, a client ID and a client password must be used. These values must have been provided by the OIDC server provider.

--- a/kolibri_oidc_client_plugin/kolibri_plugin.py
+++ b/kolibri_oidc_client_plugin/kolibri_plugin.py
@@ -2,9 +2,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.conf import settings
+from django.urls import reverse
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.core.hooks import LogoutRedirectHook
 from kolibri.plugins.user import hooks
 
 
@@ -22,3 +25,20 @@ class LoginItem(webpack_hooks.WebpackBundleHook):
 @register_hook
 class LoginItemInclusionHook(hooks.UserSyncHook):
     bundle_class = LoginItem
+
+
+@register_hook
+class EnableOIDCClient(LogoutRedirectHook):
+    @property
+    def url(self):
+        logout_endpoint = settings.OIDC_OP_LOGOUT_ENDPOINT
+        if logout_endpoint:
+            provider_logout_redirect_url = "{endpoint}/?post_logout_redirect_uri={server}{redirect}".format(
+                endpoint=logout_endpoint,
+                server=settings.OIDC_CLIENT_URL,
+                redirect=reverse(settings.OIDC_AUTHENTICATION_CALLBACK_URL),
+            )
+        else:
+            provider_logout_redirect_url = "/"
+        return provider_logout_redirect_url
+        # return 'http://localhost:8080/auth/realms/master/protocol/openid-connect/logout/?post_logout_redirect_uri=http://localhost:8000/oidccallback/'

--- a/kolibri_oidc_client_plugin/options.py
+++ b/kolibri_oidc_client_plugin/options.py
@@ -3,6 +3,11 @@ option_spec = {
         "PROVIDER_URL": {
             "type": "string",
             "default": "http://127.0.0.1:5002/oauth",
+            "envvars": ("KOLIBRI_OIDC_PROVIDER_URL",),
+        },
+        "CLIENT_URL": {
+            "type": "string",
+            "default": "http://localhost:8000",
             "envvars": ("KOLIBRI_OIDC_CLIENT_URL",),
         },
         "AUTHORIZATION_ENDPOINT": {
@@ -19,6 +24,11 @@ option_spec = {
             "type": "string",
             "default": "",
             "envvars": ("KOLIBRI_OIDC_USERINFO_ENDPOINT",),
+        },
+        "ENDSESSION_ENDPOINT": {
+            "type": "string",
+            "default": "",
+            "envvars": ("KOLIBRI_OIDC_ENDSESSION_ENDPOINT",),
         },
         "JWKS_URI": {
             "type": "string",

--- a/kolibri_oidc_client_plugin/settings.py
+++ b/kolibri_oidc_client_plugin/settings.py
@@ -12,20 +12,22 @@ OIDC_RP_CLIENT_ID = os.environ.get("CLIENT_ID", "kolibri.app")
 OIDC_RP_CLIENT_SECRET = os.environ.get("CLIENT_SECRET", "kolibri.app")
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_AUTHENTICATION_CALLBACK_URL = "oidc_client:oidc_authentication_callback"
-OIDC_OP_AUTHORIZATION_ENDPOINT = OPTIONS["OIDCClient"][
-    "AUTHORIZATION_ENDPOINT"
-] or "{}/authorize".format(OIDC_URL)
-OIDC_OP_JWKS_ENDPOINT = OPTIONS["OIDCClient"]["JWKS_URI"] or "{}/jwks".format(
-    OIDC_URL
+OIDC_OP_AUTHORIZATION_ENDPOINT = OPTIONS["OIDCClient"].get(
+    "AUTHORIZATION_ENDPOINT", "{}/authorize".format(OIDC_URL)
 )
-OIDC_OP_TOKEN_ENDPOINT = OPTIONS["OIDCClient"]["TOKEN_ENDPOINT"] or "{}/token".format(
-    OIDC_URL
+OIDC_OP_JWKS_ENDPOINT = OPTIONS["OIDCClient"].get(
+    "JWKS_URI", "{}/jwks".format(OIDC_URL)
 )
-OIDC_OP_USER_ENDPOINT = OPTIONS["OIDCClient"]["USERINFO_ENDPOINT"] or "{}/userinfo".format(
-    OIDC_URL
+OIDC_OP_TOKEN_ENDPOINT = OPTIONS["OIDCClient"].get(
+    "TOKEN_ENDPOINT", "{}/token".format(OIDC_URL)
 )
+OIDC_OP_USER_ENDPOINT = OPTIONS["OIDCClient"].get(
+    "USERINFO_ENDPOINT", "{}/userinfo".format(OIDC_URL)
+)
+OIDC_OP_LOGOUT_ENDPOINT = OPTIONS["OIDCClient"].get("ENDSESSION_ENDPOINT", None)
+OIDC_CLIENT_URL = OPTIONS["OIDCClient"].get("CLIENT_URL", "")
 OIDC_VERIFY_SSL = False
 OIDC_TOKEN_USE_BASIC_AUTH = True
-OIDC_RP_SCOPES = "openid profile"
+OIDC_RP_SCOPES = "openid profile email"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_REDIRECT_URL = "/"


### PR DESCRIPTION
Merging this PR kolibri will be able to logout from the OIDC provider.
Two new options have been added to the plugin options:

- url in the OIDC provider to end the session
- base url of the kolibri server to redirect after signing out

Closes: #6 