### PR TITLE
Fix alignment 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ target/
 # virtualenv
 venv/
 ENV/
+.venv/
+Pipfile
 
 # Spyder project settings
 .spyderproject

--- a/kolibri_oidc_client_plugin/assets/src/views/OIDCLogin.vue
+++ b/kolibri_oidc_client_plugin/assets/src/views/OIDCLogin.vue
@@ -2,13 +2,13 @@
 
   <a
     href="/oidcauthenticate/"
-    class="button secondary raised"
+    class="button raised secondary"
   >
     <file-svg
       slot="icon"
       src="./openid.svg"
     />
-    {{ $tr('signInWithOpenIDConnect') }}
+    <div>{{ $tr('signInWithOpenIDConnect') }}</div>
   </a>
 
 </template>


### PR DESCRIPTION
When using the plugin with kolibri 0.14, the svg and link are misaligned:
![image](https://user-images.githubusercontent.com/1008178/87174890-248a7680-c2d8-11ea-8d54-16989a80ba0b.png)
After this small change:
![after](https://user-images.githubusercontent.com/1008178/87174915-2d7b4800-c2d8-11ea-97bd-a525d7aae720.png)
